### PR TITLE
Publish sources artifact with delombok

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,7 @@
 plugins {
     id 'java-library'
+    id 'maven-publish'
+    id 'io.freefair.lombok' version '6.4.2'
 }
 
 group 'dev.xdark'
@@ -17,6 +19,11 @@ targetCompatibility = 1.8
 
 tasks.withType(JavaCompile) {
     options.compilerArgs.addAll(['-parameters', '-g:lines,source,vars'])
+}
+
+task sourcesJar(type: Jar) {
+    from sourceSets.main.delombokTask
+    classifier = 'sources'
 }
 
 dependencies {
@@ -39,4 +46,19 @@ dependencies {
 
 test {
     useJUnitPlatform()
+}
+
+publishing {
+    repositories {
+        maven {
+            name = 'tmp-delombok-repo'
+            url = 'file:///tmp/delombok-repo'
+        }
+    }
+    publications {
+        maven(MavenPublication) {
+            from components.java
+            artifact sourcesJar
+        }
+    }
 }


### PR DESCRIPTION
Actual source unaffected, applies delombok to the source before publishing the sources artifact.

Before:
![image](https://user-images.githubusercontent.com/21371686/163139239-bacf4558-2b2b-4e2d-a7ee-cad9b433cceb.png)

After:
![image](https://user-images.githubusercontent.com/21371686/163139684-4fc1b8b6-2aec-42b9-9c35-1149cbac6772.png)
