### PR TITLE
Allow unregistering classes

### DIFF
--- a/src/main/java/dev/xdark/ssvm/classloading/ClassLoaderData.java
+++ b/src/main/java/dev/xdark/ssvm/classloading/ClassLoaderData.java
@@ -19,6 +19,25 @@ public interface ClassLoaderData {
 	 */
 	InstanceJavaClass getClass(String name);
 
+	/**
+	 * Checks if a class has been linked.
+	 *
+	 * @param name
+	 * 		Name of the class.
+	 *
+	 * @return {@code true} when the class exists.
+	 */
+	boolean hasClass(String name);
+
+	/**
+	 * Unregisters a class by its name.
+	 *
+	 * @param name
+	 * 		Name of the class.
+	 *
+	 * @return {@code true} when the class existed, and was successfully unlinked.
+	 */
+	boolean unlinkClass(String name);
 
 	/**
 	 * Attempts to register a class.

--- a/src/main/java/dev/xdark/ssvm/classloading/SimpleClassLoaderData.java
+++ b/src/main/java/dev/xdark/ssvm/classloading/SimpleClassLoaderData.java
@@ -20,6 +20,16 @@ public final class SimpleClassLoaderData implements ClassLoaderData {
 	}
 
 	@Override
+	public boolean hasClass(String name) {
+		return table.containsKey(name);
+	}
+
+	@Override
+	public boolean unlinkClass(String name) {
+		return table.remove(name) != null;
+	}
+
+	@Override
 	public void linkClass(InstanceJavaClass jc) {
 		String name = jc.getInternalName();
 		if (table.putIfAbsent(name, jc) != null) {


### PR DESCRIPTION
Useful if the loader implementation is pulling from a dynamic source _(Class bytecode can change)_ such as Recaf. Or possibly a runtime being instrumented.

Should be usable via `vm.getBootClassLoaderData().unlinkClass(internalName);`