### PR TITLE
Create intermediate builder model for VM and VM-interface to allow creating simple copies

### DIFF
--- a/ssvm-core/src/main/java/dev/xdark/ssvm/VirtualMachine.java
+++ b/ssvm-core/src/main/java/dev/xdark/ssvm/VirtualMachine.java
@@ -93,6 +93,47 @@ public class VirtualMachine implements VMEventCollection {
 	private volatile InstanceValue systemThreadGroup;
 	private volatile InstanceValue mainThreadGroup;
 
+	/*
+	 * Constructor for copying, see VirtualMachineBuilder
+	 */
+	VirtualMachine(VMInterface vmInterface, MemoryAllocator memoryAllocator, ObjectSynchronizer objectSynchronizer,
+				   MemoryManager memoryManager, ClassDefiner classDefiner, ThreadManager threadManager,
+				   FileManager fileManager, NativeLibraryManager nativeLibraryManager, TimeManager timeManager,
+				   ManagementInterface managementInterface, StringPool stringPool, ClassLoaders classLoaders,
+				   ExecutionEngine executionEngine, MirrorFactory mirrorFactory, BootClassFinder bootClassFinder,
+				   ClassStorage classStorage, LinkResolver linkResolver, RuntimeResolver runtimeResolver,
+				   Map<String, String> properties, Map<String, String> env, Reflection reflection, JVMTI jvmti,
+				   VMOperations operations, Symbols symbols, Primitives primitives, InstanceValue systemThreadGroup,
+				   InstanceValue mainThreadGroup) {
+		this.vmInterface = vmInterface;
+		this.memoryAllocator = memoryAllocator;
+		this.objectSynchronizer = objectSynchronizer;
+		this.memoryManager = memoryManager;
+		this.classDefiner = classDefiner;
+		this.threadManager = threadManager.copyForVm(this);
+		this.fileManager = fileManager;
+		this.nativeLibraryManager = nativeLibraryManager;
+		this.timeManager = timeManager;
+		this.managementInterface = managementInterface;
+		this.stringPool = stringPool;
+		this.classLoaders = classLoaders;
+		this.executionEngine = executionEngine;
+		this.mirrorFactory = mirrorFactory;
+		this.bootClassFinder = bootClassFinder;
+		this.classStorage = classStorage;
+		this.linkResolver = linkResolver;
+		this.runtimeResolver = runtimeResolver;
+		this.properties = properties;
+		this.env = env;
+		this.reflection = reflection;
+		this.jvmti = jvmti;
+		this.operations = operations;
+		this.symbols = symbols;
+		this.primitives = primitives;
+		this.systemThreadGroup = systemThreadGroup;
+		this.mainThreadGroup = mainThreadGroup;
+	}
+
 	public VirtualMachine() {
 		vmInterface = createVMInterface();
 		DelegatingSymbols delegatingSymbols = new DelegatingSymbols();
@@ -124,6 +165,13 @@ public class VirtualMachine implements VMEventCollection {
 		reflection = new Reflection(this);
 		jvmti = new JVMTI(this);
 		operations = new VMOperations(this);
+	}
+
+	/**
+	 * @return New builder with values copied from this VM.
+	 */
+	public VirtualMachineBuilder toBuilder() {
+		return new VirtualMachineBuilder(this);
 	}
 
 	protected VMInterface createVMInterface() {
@@ -277,6 +325,13 @@ public class VirtualMachine implements VMEventCollection {
 	 */
 	public VMInterface getInterface() {
 		return vmInterface;
+	}
+
+	/**
+	 * @return JVMTI manager.
+	 */
+	public JVMTI getJvmti() {
+		return jvmti;
 	}
 
 	/**

--- a/ssvm-core/src/main/java/dev/xdark/ssvm/VirtualMachineBuilder.java
+++ b/ssvm-core/src/main/java/dev/xdark/ssvm/VirtualMachineBuilder.java
@@ -1,0 +1,165 @@
+package dev.xdark.ssvm;
+
+import dev.xdark.ssvm.api.VMInterface;
+import dev.xdark.ssvm.classloading.BootClassFinder;
+import dev.xdark.ssvm.classloading.ClassDefiner;
+import dev.xdark.ssvm.classloading.ClassLoaders;
+import dev.xdark.ssvm.classloading.ClassStorage;
+import dev.xdark.ssvm.execution.ExecutionEngine;
+import dev.xdark.ssvm.filesystem.FileManager;
+import dev.xdark.ssvm.jni.NativeLibraryManager;
+import dev.xdark.ssvm.jvm.ManagementInterface;
+import dev.xdark.ssvm.memory.allocation.MemoryAllocator;
+import dev.xdark.ssvm.memory.management.MemoryManager;
+import dev.xdark.ssvm.memory.management.StringPool;
+import dev.xdark.ssvm.mirror.MirrorFactory;
+import dev.xdark.ssvm.operation.VMOperations;
+import dev.xdark.ssvm.symbol.Primitives;
+import dev.xdark.ssvm.symbol.Symbols;
+import dev.xdark.ssvm.synchronizer.ObjectSynchronizer;
+import dev.xdark.ssvm.thread.ThreadManager;
+import dev.xdark.ssvm.timezone.TimeManager;
+import dev.xdark.ssvm.util.Reflection;
+import dev.xdark.ssvm.value.InstanceValue;
+
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * An intermediate 'builder' for {@link VirtualMachine} which allows swapping out of a few components of an existing VM.
+ *
+ * @author Matt Coley
+ */
+public class VirtualMachineBuilder {
+	private AtomicReference<InitializationState> state;
+	private VMInterface vmInterface;
+	private MemoryAllocator memoryAllocator;
+	private ObjectSynchronizer objectSynchronizer;
+	private MemoryManager memoryManager;
+	private ClassDefiner classDefiner;
+	private ThreadManager threadManager;
+	private FileManager fileManager;
+	private NativeLibraryManager nativeLibraryManager;
+	private TimeManager timeManager;
+	private ManagementInterface managementInterface;
+	private StringPool stringPool;
+	private ClassLoaders classLoaders;
+	private ExecutionEngine executionEngine;
+	private MirrorFactory mirrorFactory;
+	private BootClassFinder bootClassFinder;
+	private ClassStorage classStorage;
+	private LinkResolver linkResolver;
+	private RuntimeResolver runtimeResolver;
+	private Map<String, String> properties;
+	private Map<String, String> env;
+	private Reflection reflection;
+	private JVMTI jvmti;
+	private VMOperations operations;
+	private Symbols symbols;
+	private Primitives primitives;
+	private InstanceValue systemThreadGroup;
+	private InstanceValue mainThreadGroup;
+
+	/**
+	 * @param vm Base VM to copy values from.
+	 */
+	VirtualMachineBuilder(VirtualMachine vm) {
+		this.vmInterface = vm.getInterface();
+		this.memoryAllocator = vm.getMemoryAllocator();
+		this.objectSynchronizer = vm.getObjectSynchronizer();
+		this.memoryManager = vm.getMemoryManager();
+		this.classDefiner = vm.getClassDefiner();
+		this.threadManager = vm.getThreadManager();
+		this.fileManager = vm.getFileManager();
+		this.nativeLibraryManager = vm.getNativeLibraryManager();
+		this.timeManager = vm.getTimeManager();
+		this.managementInterface = vm.getManagementInterface();
+		this.stringPool = vm.getStringPool();
+		this.classLoaders = vm.getClassLoaders();
+		this.executionEngine = vm.getExecutionEngine();
+		this.mirrorFactory = vm.getMirrorFactory();
+		this.bootClassFinder = vm.getBootClassFinder();
+		this.classStorage = vm.getClassStorage();
+		this.linkResolver = vm.getLinkResolver();
+		this.runtimeResolver = vm.getRuntimeResolver();
+		this.properties = vm.getProperties();
+		this.env = vm.getenv();
+		this.reflection = vm.getReflection();
+		this.jvmti = vm.getJvmti();
+		this.operations = vm.getOperations();
+		this.symbols = vm.getSymbols();
+		this.primitives = vm.getPrimitives();
+		this.systemThreadGroup = vm.getSystemThreadGroup();
+		this.mainThreadGroup = vm.getMainThreadGroup();
+	}
+
+	/**
+	 * @see VMInterface#copy() Used to deep copy an existing VM interface.
+	 * @param vmInterface New VM interface to use.
+	 * @return Self.
+	 */
+	public VirtualMachineBuilder withVmInterface(VMInterface vmInterface) {
+		this.vmInterface = vmInterface;
+		return this;
+	}
+
+	/**
+	 * @param fileManager New file manager to use.
+	 * @return Self.
+	 */
+	public VirtualMachineBuilder withFileManager(FileManager fileManager) {
+		this.fileManager = fileManager;
+		return this;
+	}
+
+	/**
+	 * @param timeManager New time manager to use.
+	 * @return Self.
+	 */
+	public VirtualMachineBuilder withTimeManager(TimeManager timeManager) {
+		this.timeManager = timeManager;
+		return this;
+	}
+
+	/**
+	 * @param executionEngine New execution engine to use.
+	 * @return Self.
+	 */
+	public VirtualMachineBuilder withExecutionEngine(ExecutionEngine executionEngine) {
+		this.executionEngine = executionEngine;
+		return this;
+	}
+
+	/**
+	 * @return New VM with values from this builder.
+	 */
+	public VirtualMachine build() {
+		return new VirtualMachine(vmInterface,
+				memoryAllocator,
+				objectSynchronizer,
+				memoryManager,
+				classDefiner,
+				threadManager,
+				fileManager,
+				nativeLibraryManager,
+				timeManager,
+				managementInterface,
+				stringPool,
+				classLoaders,
+				executionEngine,
+				mirrorFactory,
+				bootClassFinder,
+				classStorage,
+				linkResolver,
+				runtimeResolver,
+				properties,
+				env,
+				reflection,
+				jvmti,
+				operations,
+				symbols,
+				primitives,
+				systemThreadGroup,
+				mainThreadGroup);
+	}
+}

--- a/ssvm-core/src/main/java/dev/xdark/ssvm/api/DelegatingVMInterface.java
+++ b/ssvm-core/src/main/java/dev/xdark/ssvm/api/DelegatingVMInterface.java
@@ -138,4 +138,9 @@ public class DelegatingVMInterface implements VMInterface {
 	public void handleMaxInterations(ExecutionContext<?> ctx) {
 		delegate.handleMaxInterations(ctx);
 	}
+
+	@Override
+	public VMInterface copy() {
+		return delegate.copy();
+	}
 }

--- a/ssvm-core/src/main/java/dev/xdark/ssvm/api/VMInterface.java
+++ b/ssvm-core/src/main/java/dev/xdark/ssvm/api/VMInterface.java
@@ -1,5 +1,6 @@
 package dev.xdark.ssvm.api;
 
+import dev.xdark.ssvm.VirtualMachine;
 import dev.xdark.ssvm.asm.Modifier;
 import dev.xdark.ssvm.execution.ExecutionContext;
 import dev.xdark.ssvm.execution.InstructionProcessor;
@@ -175,4 +176,13 @@ public interface VMInterface {
 	 * @param ctx Context of the native method that interpreted {@link Interpreter#getMaxIterations() the maximum number of allowed iterations}.
 	 */
 	void handleMaxInterations(ExecutionContext<?> ctx);
+
+	/**
+	 * Copying this interface may be viable when combined with {@link VirtualMachine#toBuilder()} to create basic
+	 * <i>"scopes"</i>. Each scope can have its own set of listeners and interceptors, while not polluting other
+	 * {@link VMInterface} instances.
+	 *
+	 * @return Copy of this interface.
+	 */
+	VMInterface copy();
 }

--- a/ssvm-core/src/main/java/dev/xdark/ssvm/execution/ExecutionContext.java
+++ b/ssvm-core/src/main/java/dev/xdark/ssvm/execution/ExecutionContext.java
@@ -1,9 +1,7 @@
 package dev.xdark.ssvm.execution;
 
-import dev.xdark.ssvm.VirtualMachine;
 import dev.xdark.ssvm.mirror.member.JavaMethod;
 import dev.xdark.ssvm.mirror.type.InstanceClass;
-import dev.xdark.ssvm.operation.VMOperations;
 import dev.xdark.ssvm.util.VMFunctions;
 import dev.xdark.ssvm.value.ObjectValue;
 import dev.xdark.ssvm.value.sink.ValueSink;
@@ -113,13 +111,5 @@ public interface ExecutionContext<R extends ValueSink> extends VMFunctions {
 	 */
 	default ObjectValue getClassLoader() {
 		return getOwner().getClassLoader();
-	}
-
-	/**
-	 * @return VM instance in which method is being executed.
-	 */
-	@Override
-	default VirtualMachine getVM() {
-		return getOwner().getVM();
 	}
 }

--- a/ssvm-core/src/main/java/dev/xdark/ssvm/thread/ThreadManager.java
+++ b/ssvm-core/src/main/java/dev/xdark/ssvm/thread/ThreadManager.java
@@ -1,5 +1,6 @@
 package dev.xdark.ssvm.thread;
 
+import dev.xdark.ssvm.VirtualMachine;
 import dev.xdark.ssvm.thread.backtrace.Backtrace;
 import dev.xdark.ssvm.value.InstanceValue;
 
@@ -12,7 +13,6 @@ import java.util.List;
  * @see OSThread
  */
 public interface ThreadManager {
-
 	/**
 	 * Starts the thread, assigns new OS thread to
 	 * the {@code oop} instance.
@@ -148,4 +148,10 @@ public interface ThreadManager {
 	 * @return Java thread or {@code null}, if thread is not alive.
 	 */
 	JavaThread getThread(InstanceValue oop);
+
+	/**
+	 * @param newVm New VM for the copied thread manager to reside in.
+	 * @return Copy of thread manager.
+	 */
+	ThreadManager copyForVm(VirtualMachine newVm);
 }

--- a/ssvm-core/src/main/java/dev/xdark/ssvm/thread/backtrace/SimpleBacktrace.java
+++ b/ssvm-core/src/main/java/dev/xdark/ssvm/thread/backtrace/SimpleBacktrace.java
@@ -1,5 +1,6 @@
 package dev.xdark.ssvm.thread.backtrace;
 
+import dev.xdark.ssvm.VirtualMachine;
 import dev.xdark.ssvm.execution.ExecutionContext;
 import dev.xdark.ssvm.execution.ExecutionRequest;
 import dev.xdark.ssvm.util.CloseableUtil;
@@ -18,9 +19,11 @@ public final class SimpleBacktrace implements Backtrace {
 
 	private static final int RESERVED_FRAMES = 12;
 	private final List<ExecutionContext<?>> frames;
+	private final VirtualMachine vm;
 	private int frame;
 
-	public SimpleBacktrace(int frameCount) {
+	public SimpleBacktrace(VirtualMachine vm, int frameCount) {
+		this.vm = vm;
 		frames = Arrays.asList(new ExecutionContext[Math.max(frameCount, RESERVED_FRAMES + 4)]);
 	}
 
@@ -33,7 +36,7 @@ public final class SimpleBacktrace implements Backtrace {
 		}
 		SimpleExecutionContext<R> ctx = (SimpleExecutionContext<R>) frames.get(frameIndex);
 		if (ctx == null) {
-			ctx = new SimpleExecutionContext<>();
+			ctx = new SimpleExecutionContext<>(vm);
 			frames.set(frameIndex, ctx);
 		}
 		ctx.init(request.getMethod(), request.getStack(), request.getLocals(), request.getResultSink());

--- a/ssvm-core/src/main/java/dev/xdark/ssvm/thread/backtrace/SimpleExecutionContext.java
+++ b/ssvm-core/src/main/java/dev/xdark/ssvm/thread/backtrace/SimpleExecutionContext.java
@@ -1,5 +1,6 @@
 package dev.xdark.ssvm.thread.backtrace;
 
+import dev.xdark.ssvm.VirtualMachine;
 import dev.xdark.ssvm.execution.ExecutionContext;
 import dev.xdark.ssvm.execution.Locals;
 import dev.xdark.ssvm.execution.Stack;
@@ -12,12 +13,22 @@ import dev.xdark.ssvm.value.sink.ValueSink;
 
 final class SimpleExecutionContext<R extends ValueSink> implements ExecutionContext<R>, SafeCloseable {
 
+	private final VirtualMachine vm;
 	private JavaMethod method;
 	private Stack stack;
 	private Locals locals;
 	private R sink;
 	private int insnPosition;
 	private int lineNumber = -1;
+
+	SimpleExecutionContext(VirtualMachine vm) {
+		this.vm = vm;
+	}
+
+	@Override
+	public VirtualMachine getVM() {
+		return vm;
+	}
 
 	@Override
 	public JavaMethod getMethod() {


### PR DESCRIPTION
This is intended for the use case where you initiate one 'base' VM and want to re-use it with different operations that may not have compatible `VMInterface` processors. Now you can create shallow `VirtualMachine` copies with a modified `VMInterface` value and operate on each VM copy.

```java
VirtualMachine base = ...

VirtualMachine  copy = vm.toBuilder()
		.withVmInterface(vmInterface.copy())
		.build()
copy.getInterface().registerInstructionInterceptor(...) // Only affects 'copy' but not origin 'base' VM
```